### PR TITLE
将超过 int64 的 uint64 数据删掉

### DIFF
--- a/pipeline/schemafree.go
+++ b/pipeline/schemafree.go
@@ -360,10 +360,44 @@ func copyAndConvertData(d Data, mapLevel int) Data {
 			} else {
 				v = map[string]interface{}(copyAndConvertData(nv, mapLevel+1))
 			}
+		case []uint64:
+			if len(nv) == 0 {
+				continue
+			}
+			newArr := make([]int64, 0)
+			for _, value := range nv {
+				if int64(value) < 0 {
+					continue
+				}
+				newArr = append(newArr, int64(value))
+			}
+			v = newArr
 		case []interface{}:
 			if len(nv) == 0 {
 				continue
 			}
+			switch nv[0].(type) {
+			case uint64:
+				newArr := make([]interface{}, 0)
+				for _, value := range nv {
+					switch newV := value.(type) {
+					case uint64:
+						if int64(newV) < 0 {
+							continue
+						}
+						newArr = append(newArr, int64(newV))
+					default:
+						newArr = append(newArr, newV)
+					}
+				}
+				v = newArr
+			}
+		case uint64:
+			newV := int64(nv)
+			if newV < 0 {
+				continue
+			}
+			v = newV
 		case nil:
 			continue
 		}

--- a/pipeline/schemafree_test.go
+++ b/pipeline/schemafree_test.go
@@ -949,6 +949,12 @@ func TestCopyAndConvertData(t *testing.T) {
 		"a": "a",
 		"b": 1,
 		"c": nil,
+		"g": uint64(9223372036854776000),
+		"h": uint64(9223372036851822000),
+		"i": uint64(1),
+		"j": []interface{}{int(1), uint64(9223372036854776000), uint64(9223372036851822000)},
+		"k": []uint64{uint64(9223372036854776000), uint64(1), uint64(9223372036851822000)},
+		"l": []interface{}{uint64(9223372036854776000), int(1), uint64(9223372036851822000)},
 		"e": []interface{}{},
 		"f": map[string]interface{}{},
 		"d": map[string]interface{}{
@@ -1006,6 +1012,11 @@ func TestCopyAndConvertData(t *testing.T) {
 	expData := Data{
 		"a": "a",
 		"b": 1,
+		"i": int64(1),
+		"h": int64(9223372036851822000),
+		"k": []int64{int64(1), int64(9223372036851822000)},
+		"l": []interface{}{int(1), int64(9223372036851822000)},
+		"j": []interface{}{int(1), uint64(9223372036854776000), uint64(9223372036851822000)},
 		"d": map[string]interface{}{
 			"a_1": "a",
 			"b1":  1,


### PR DESCRIPTION
## Fixes [PDR-XXX](pdr-link-address)

## Changes
   
  - [ ] 将超过 int64 的 uint64 数据删掉, 对于 []interface{} 这中类型，只有第一个元素的类型为 uint64 时，才会去遍历数组
 
## Reviewers

  - [ ] @[someone] please review
  - [ ] @[someotherone] please review
    
## Checklist
   
   - [ ] Rebased/mergable
   - [ ] Tests pass
   - [ ] CHANGELOG.md updated
   - [ ] Jira issue/task done