### PR TITLE
去除自动推断为PandoraTypeIP

### DIFF
--- a/pipeline/models.go
+++ b/pipeline/models.go
@@ -399,6 +399,8 @@ func getRawType(tp string) (schemaType string, err error) {
 		schemaType = PandoraTypeBool
 	case "j", "json", "jsonstring":
 		schemaType = PandoraTypeJsonString
+	case "i", "ip":
+		schemaType = PandoraTypeIP
 	case "": //这个是一种缺省
 	default:
 		err = fmt.Errorf("schema type %v not supperted", schemaType)

--- a/pipeline/schemafree.go
+++ b/pipeline/schemafree.go
@@ -3,7 +3,6 @@ package pipeline
 import (
 	"encoding/json"
 	"fmt"
-	"net"
 	"reflect"
 	"sort"
 	"strconv"
@@ -1069,11 +1068,9 @@ func GetTrimedDataSchema(data Data) (valueType map[string]RepoSchemaEntry) {
 			// 由于数据为空，且无法判断类型, 所以从数据中将该条键值对删掉
 			delete(data, k)
 		case string:
-			// 如果数据满足date格式，则推断为PandoraTypeDate，如果数据满足IP格式，则推断为PandoraTypeIP
+			// 如果数据满足date格式，则推断为PandoraTypeDate
 			if _, err := time.Parse(time.RFC3339, nv); err == nil {
 				valueType[k] = formValueType(k, PandoraTypeDate)
-			} else if ipAddr := net.ParseIP(nv); ipAddr != nil {
-				valueType[k] = formValueType(k, PandoraTypeIP)
 			} else {
 				valueType[k] = formValueType(k, PandoraTypeString)
 			}

--- a/pipeline/schemafree_test.go
+++ b/pipeline/schemafree_test.go
@@ -45,7 +45,7 @@ func TestGetTrimedDataSchemaBase(t *testing.T) {
 		"g": gmp,
 		"i": imp,
 		"j": jmp,
-		"k": formValueType("k", PandoraTypeIP),
+		"k": formValueType("k", PandoraTypeString),
 	}
 	assert.NoError(t, err)
 	vt := GetTrimedDataSchema(data)
@@ -128,7 +128,7 @@ func TestGetTrimedDataSchemaBase(t *testing.T) {
 		"h3": hmp3,
 
 		"i": formValueType("i", PandoraTypeBool),
-		"j": formValueType("j", PandoraTypeIP),
+		"j": formValueType("j", PandoraTypeString),
 	}
 	vt = GetTrimedDataSchema(data)
 	assert.Equal(t, exp, vt)


### PR DESCRIPTION
@wonderflow 
@ZhuangZuoQN

 数据满足IP格式时，不能保证字段的值全都是IP格式，可能也会为host，则不满足，直接推断为IP格式，就会丢失用户数据，所以不应该直接推断为PandoraTypeIP